### PR TITLE
[Fix] onTabReselected been called when tab first selected

### DIFF
--- a/demo/src/main/java/nl/joery/demo/animatedbottombar/viewpager/ViewPagerActivity.kt
+++ b/demo/src/main/java/nl/joery/demo/animatedbottombar/viewpager/ViewPagerActivity.kt
@@ -1,6 +1,7 @@
 package nl.joery.demo.animatedbottombar.viewpager
 
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
@@ -23,6 +24,14 @@ class ViewPagerActivity : FragmentActivity() {
                 lifecycle
             )
         bottom_bar.setupWithViewPager2(view_pager)
+        bottom_bar.apply {
+            onTabSelected = {
+                Log.i("ViewPagerActivity", "onTabSelected: ${it.title}")
+            }
+            onTabReselected = {
+                Log.i("ViewPagerActivity", "onTabReselected: ${it.title}")
+            }
+        }
     }
 
     private fun initToolbar() {

--- a/library/src/main/java/nl/joery/animatedbottombar/AnimatedBottomBar.kt
+++ b/library/src/main/java/nl/joery/animatedbottombar/AnimatedBottomBar.kt
@@ -474,18 +474,19 @@ class AnimatedBottomBar @JvmOverloads constructor(
         if (viewPager != null) {
             selectTabAt(viewPager.currentItem, false)
             viewPager.addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
-                private var previousState:Int = ViewPager.SCROLL_STATE_IDLE
+                private var previousState: Int = ViewPager.SCROLL_STATE_IDLE
                 private var userScrollChange = false
                 override fun onPageScrollStateChanged(state: Int) {
                     // Use Scroll state to detect whether the user is sliding
                     if (previousState == ViewPager.SCROLL_STATE_DRAGGING
-                        && state == ViewPager.SCROLL_STATE_SETTLING)
+                        && state == ViewPager.SCROLL_STATE_SETTLING
+                    ) {
                         userScrollChange = true
-
-                    else if (previousState == ViewPager.SCROLL_STATE_SETTLING
-                        && state == ViewPager.SCROLL_STATE_IDLE)
+                    } else if (previousState == ViewPager.SCROLL_STATE_SETTLING
+                        && state == ViewPager.SCROLL_STATE_IDLE
+                    ) {
                         userScrollChange = false
-
+                    }
                     previousState = state
                 }
 
@@ -497,12 +498,10 @@ class AnimatedBottomBar @JvmOverloads constructor(
                 }
 
                 override fun onPageSelected(position: Int) {
-                    if (userScrollChange){
-                        // Swap by user touch, change adapter to new tab.
+                    if (userScrollChange) {
+                        // Swap by user's touch, change adapter to new tab.
                         selectTabAt(position)
-                        return
                     }
-                    // Programmatically setting should't call selectTabAt again
                 }
             })
         }
@@ -526,23 +525,21 @@ class AnimatedBottomBar @JvmOverloads constructor(
                     // Use Scroll state to detect whether the user is sliding
                     if (previousState == ViewPager2.SCROLL_STATE_DRAGGING
                         && state == ViewPager2.SCROLL_STATE_SETTLING
-                    )
+                    ) {
                         userScrollChange = true
-                    else if (previousState == ViewPager2.SCROLL_STATE_SETTLING
+                    } else if (previousState == ViewPager2.SCROLL_STATE_SETTLING
                         && state == ViewPager2.SCROLL_STATE_IDLE
-                    )
+                    ) {
                         userScrollChange = false
-
+                    }
                     previousState = state
                 }
 
                 override fun onPageSelected(position: Int) {
-                    if (userScrollChange){
-                        // Swap by user touch, change adapter to new tab.
+                    if (userScrollChange) {
+                        // Swap by user's touch, change adapter to new tab.
                         selectTabAt(position)
-                        return
                     }
-                    // Programmatically setting should't call selectTabAt again
                 }
             })
         }

--- a/library/src/main/java/nl/joery/animatedbottombar/AnimatedBottomBar.kt
+++ b/library/src/main/java/nl/joery/animatedbottombar/AnimatedBottomBar.kt
@@ -16,6 +16,7 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager.widget.ViewPager
 import androidx.viewpager2.widget.ViewPager2
+import androidx.viewpager2.widget.ViewPager2.SCROLL_STATE_IDLE
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexWrap
 import com.google.android.flexbox.FlexboxLayoutManager
@@ -472,7 +473,19 @@ class AnimatedBottomBar @JvmOverloads constructor(
         if (viewPager != null) {
             selectTabAt(viewPager.currentItem, false)
             viewPager.addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
+                private var previousState:Int = ViewPager.SCROLL_STATE_IDLE
+                private var userScrollChange = false
                 override fun onPageScrollStateChanged(state: Int) {
+                    // Use Scroll state to detect whether the user is sliding
+                    if (previousState == ViewPager.SCROLL_STATE_DRAGGING
+                        && state == ViewPager.SCROLL_STATE_SETTLING)
+                        userScrollChange = true
+
+                    else if (previousState == ViewPager.SCROLL_STATE_SETTLING
+                        && state == ViewPager.SCROLL_STATE_IDLE)
+                        userScrollChange = false
+
+                    previousState = state
                 }
 
                 override fun onPageScrolled(
@@ -483,7 +496,12 @@ class AnimatedBottomBar @JvmOverloads constructor(
                 }
 
                 override fun onPageSelected(position: Int) {
-                    selectTabAt(position)
+                    if (userScrollChange){
+                        // Swap by user touch, change adapter to new tab.
+                        selectTabAt(position)
+                        return
+                    }
+                    // Programmatically setting should't call selectTabAt again
                 }
             })
         }
@@ -500,8 +518,29 @@ class AnimatedBottomBar @JvmOverloads constructor(
         if (viewPager2 != null) {
             selectTabAt(viewPager2.currentItem, false)
             viewPager2.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+                private var previousState:Int = SCROLL_STATE_IDLE
+                private var userScrollChange = false
+                override fun onPageScrollStateChanged(state: Int) {
+                    super.onPageScrollStateChanged(state)
+                    // Use Scroll state to detect whether the user is sliding
+                    if (previousState == ViewPager.SCROLL_STATE_DRAGGING
+                        && state == ViewPager.SCROLL_STATE_SETTLING)
+                        userScrollChange = true
+
+                    else if (previousState == ViewPager.SCROLL_STATE_SETTLING
+                        && state == ViewPager.SCROLL_STATE_IDLE)
+                        userScrollChange = false
+
+                    previousState = state
+                }
+
                 override fun onPageSelected(position: Int) {
-                    selectTabAt(position)
+                    if (userScrollChange){
+                        // Swap by user touch, change adapter to new tab.
+                        selectTabAt(position)
+                        return
+                    }
+                    // Programmatically setting should't call selectTabAt again
                 }
             })
         }

--- a/library/src/main/java/nl/joery/animatedbottombar/AnimatedBottomBar.kt
+++ b/library/src/main/java/nl/joery/animatedbottombar/AnimatedBottomBar.kt
@@ -16,7 +16,6 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager.widget.ViewPager
 import androidx.viewpager2.widget.ViewPager2
-import androidx.viewpager2.widget.ViewPager2.SCROLL_STATE_IDLE
 import com.google.android.flexbox.FlexDirection
 import com.google.android.flexbox.FlexWrap
 import com.google.android.flexbox.FlexboxLayoutManager
@@ -518,17 +517,18 @@ class AnimatedBottomBar @JvmOverloads constructor(
         if (viewPager2 != null) {
             selectTabAt(viewPager2.currentItem, false)
             viewPager2.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
-                private var previousState:Int = SCROLL_STATE_IDLE
+                private var previousState: Int = ViewPager2.SCROLL_STATE_IDLE
                 private var userScrollChange = false
                 override fun onPageScrollStateChanged(state: Int) {
                     super.onPageScrollStateChanged(state)
                     // Use Scroll state to detect whether the user is sliding
-                    if (previousState == ViewPager.SCROLL_STATE_DRAGGING
-                        && state == ViewPager.SCROLL_STATE_SETTLING)
+                    if (previousState == ViewPager2.SCROLL_STATE_DRAGGING
+                        && state == ViewPager2.SCROLL_STATE_SETTLING
+                    )
                         userScrollChange = true
-
-                    else if (previousState == ViewPager.SCROLL_STATE_SETTLING
-                        && state == ViewPager.SCROLL_STATE_IDLE)
+                    else if (previousState == ViewPager2.SCROLL_STATE_SETTLING
+                        && state == ViewPager2.SCROLL_STATE_IDLE
+                    )
                         userScrollChange = false
 
                     previousState = state

--- a/library/src/main/java/nl/joery/animatedbottombar/AnimatedBottomBar.kt
+++ b/library/src/main/java/nl/joery/animatedbottombar/AnimatedBottomBar.kt
@@ -6,6 +6,7 @@ import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.util.AttributeSet
+import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
@@ -197,6 +198,7 @@ class AnimatedBottomBar @JvmOverloads constructor(
         recycler = RecyclerView(context)
         recycler.itemAnimator = null
         recycler.layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+        recycler.overScrollMode = View.OVER_SCROLL_NEVER
 
         val flexLayoutManager = FlexboxLayoutManager(context, FlexDirection.ROW, FlexWrap.NOWRAP)
         recycler.layoutManager = flexLayoutManager


### PR DESCRIPTION
## What the problem
The `onTabReselected` also been called when the tab is first selected.

## What caused it
When the user selects a tab, would have followed call chain:

![tab](https://user-images.githubusercontent.com/15865017/82692406-42e9d380-9c92-11ea-8ccc-521745850206.png)

As you can see, when you call `ViewPager.setCurrentItem()`, the `ViewPager` will invoke `onPageSelected` automatically. So that `TabAdapter#selectTab` would be call in second times.
That is why `onTabReselected` also been called when the tab is first selected.

## How to fix it?
In `ViewPgaer.onPageScrollStateChanged`, I adding some code to detect whether if user touch or programmatically call from code. Here is the [ref](https://stackoverflow.com/questions/17819970/differentiating-between-user-scroll-and-programatic-page-change-in-viewpager).

---
This lib is awesome, Thanks for your work :D