### PR TITLE
Fix AnimatedBottomBar.indexOfTabWithId

### DIFF
--- a/library/src/main/java/nl/joery/animatedbottombar/AnimatedBottomBar.kt
+++ b/library/src/main/java/nl/joery/animatedbottombar/AnimatedBottomBar.kt
@@ -714,6 +714,8 @@ class AnimatedBottomBar @JvmOverloads constructor(
     }
 
     private fun indexOfTabWithId(@IdRes id: Int): Int {
+        val tabs = adapter.tabs
+
         for(i in tabs.indices) {
             if(tabs[i].id == id) {
                 return i


### PR DESCRIPTION
`AnimatedBottomBar.tabs` creates copy of `adapter.tabs`. It's not needed.